### PR TITLE
Initializing CoC in governance repo

### DIFF
--- a/conduct/coc_reporting.rst
+++ b/conduct/coc_reporting.rst
@@ -1,0 +1,226 @@
+PySAL Code of Conduct - How to follow up on a report
+====================================================
+
+This is the manual followed by PySAL's Code of Conduct Committee. It's
+used when we respond to an issue to make sure we're consistent and fair.
+
+Enforcing the Code of Conduct impacts our community today and for the
+future. It's an action that we do not take lightly. When reviewing
+enforcement measures, the Code of Conduct Committee will keep the
+following values and guidelines in mind:
+
+-  Act in a personal manner rather than impersonal. The Committee can
+   engage the parties to understand the situation, while respecting the
+   privacy and any necessary confidentiality of reporters. However,
+   sometimes it is necessary to communicate with one or more individuals
+   directly: the Committee's goal is to improve the health of our
+   community rather than only produce a formal decision.
+
+-  Emphasize empathy for individuals rather than judging behavior,
+   avoiding binary labels of "good" and "bad/evil". Overt, clear-cut
+   aggression and harassment exists and we will be address that firmly.
+   But many scenarios that can prove challenging to resolve are those
+   where normal disagreements devolve into unhelpful or harmful behavior
+   from multiple parties. Understanding the full context and finding a
+   path that re-engages all is hard, but ultimately the most productive
+   for our community.
+
+-  We understand that email is a difficult medium and can be isolating.
+   Receiving criticism over email, without personal contact, can be
+   particularly painful. This makes it especially important to keep an
+   atmosphere of open-minded respect of the views of others. It also
+   means that we must be transparent in our actions, and that we will do
+   everything in our power to make sure that all our members are treated
+   fairly and with sympathy.
+
+-  Discrimination can be subtle and it can be unconscious. It can show
+   itself as unfairness and hostility in otherwise ordinary
+   interactions. We know that this does occur, and we will take care to
+   look out for it. We would very much like to hear from you if you feel
+   you have been treated unfairly, and we will use these procedures to
+   make sure that your complaint is heard and addressed.
+
+-  Help increase engagement in good discussion practice: try to identify
+   where discussion may have broken down and provide actionable
+   information, pointers and resources that can lead to positive change
+   on these points.
+
+-  Be mindful of the needs of new members: provide them with explicit
+   support and consideration, with the aim of increasing participation
+   from underrepresented groups in particular.
+
+-  Individuals come from different cultural backgrounds and native
+   languages. Try to identify any honest misunderstandings caused by a
+   non-native speaker and help them understand the issue and what they
+   can change to avoid causing offence. Complex discussion in a foreign
+   language can be very intimidating, and we want to grow our diversity
+   also across nationalities and cultures.
+
+*Mediation*: voluntary, informal mediation is a tool at our disposal. In
+contexts such as when two or more parties have all escalated to the
+point of inappropriate behavior (something sadly common in human
+conflict), it may be useful to facilitate a mediation process. This is
+only an example: the Committee can consider mediation in any case,
+mindful that the process is meant to be strictly voluntary and no party
+can be pressured to participate. If the Committee suggests mediation, it
+should:
+
+-  Find a candidate who can serve as a mediator.
+-  Obtain the agreement of the reporter(s). The reporter(s) have
+   complete freedom to decline the mediation idea, or to propose an
+   alternate mediator.
+-  Obtain the agreement of the reported person(s).
+-  Settle on the mediator: while parties can propose a different
+   mediator than the suggested candidate, only if common agreement is
+   reached on all terms can the process move forward.
+-  Establish a timeline for mediation to complete, ideally within two
+   weeks.
+
+The mediator will engage with all the parties and seek a resolution that
+is satisfactory to all. Upon completion, the mediator will provide a
+report (vetted by all parties to the process) to the Committee, with
+recommendations on further steps. The Committee will then evaluate these
+results (whether satisfactory resolution was achieved or not) and decide
+on any additional action deemed necessary.
+
+
+How the committee will respond to reports
+-----------------------------------------
+
+When the committee (or a committee member) receives a report, they will
+first determine whether the report is about a clear and severe breach
+(as defined below). If so, immediate action needs to be taken in
+addition to the regular report handling process.
+
+Clear and severe breach actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We know that it is painfully common for internet communication to start
+at or devolve into obvious and flagrant abuse. We will deal quickly with
+clear and severe breaches like personal threats, violent, sexist or
+racist language.
+
+When a member of the Code of Conduct committee becomes aware of a clear
+and severe breach, they will do the following:
+
+-  Immediately disconnect the originator from all PySAL communication
+   channels.
+-  Reply to the reporter that their report has been received and that
+   the originator has been disconnected.
+-  In every case, the moderator should make a reasonable effort to
+   contact the originator, and tell them specifically how their language
+   or actions qualify as a "clear and severe breach". The moderator
+   should also say that, if the originator believes this is unfair or
+   they want to be reconnected to PySAL, they have the right to ask for
+   a review, as below, by the Code of Conduct Committee. The moderator
+   should copy this explanation to the Code of Conduct Committee.
+-  The Code of Conduct Committee will formally review and sign off on
+   all cases where this mechanism has been applied to make sure it is
+   not being used to control ordinary heated disagreement.
+
+Report handling
+~~~~~~~~~~~~~~~
+
+When a report is sent to the committee they will immediately reply to
+the reporter to confirm receipt. This reply must be sent within 72
+hours, and the group should strive to respond much quicker than that.
+
+If a report doesn't contain enough information, the committee will
+obtain all relevant data before acting. The committee is empowered to
+act on the Steering Council’s behalf in contacting any individuals
+involved to get a more complete account of events.
+
+The committee will then review the incident and determine, to the best
+of their ability:
+
+-  What happened.
+-  Whether this event constitutes a Code of Conduct violation.
+-  Who are the responsible party(ies).
+-  Whether this is an ongoing situation, and there is a threat to
+   anyone's physical safety.
+
+This information will be collected in writing, and whenever possible the
+group's deliberations will be recorded and retained (i.e. chat
+transcripts, email discussions, recorded conference calls, summaries of
+voice conversations, etc).
+
+It is important to retain an archive of all activities of this committee
+to ensure consistency in behavior and provide institutional memory for
+the project. To assist in this, the default channel of discussion for
+this committee will be a private mailing list accessible to current and
+future members of the committee as well as members of the Steering
+Council upon justified request. If the Committee finds the need to use
+off-list communications (e.g. phone calls for early/rapid response), it
+should in all cases summarize these back to the list so there's a good
+record of the process.
+
+The Code of Conduct Committee should aim to have a resolution agreed
+upon within two weeks. In the event that a resolution can't be
+determined in that time, the committee will respond to the reporter(s)
+with an update and projected timeline for resolution.
+
+
+
+Resolutions
+-----------
+
+The committee must agree on a resolution by consensus. If the group
+cannot reach consensus and deadlocks for over a week, the group will
+turn the matter over to the Steering Council for resolution.
+
+Possible responses may include:
+
+-  Taking no further action
+
+-  if we determine no violations have occurred.
+-  if the matter has been resolved publicly while the committee was
+   considering responses.
+
+-  Coordinating voluntary mediation: if all involved parties agree, the
+   Committee may facilitate a mediation process as detailed above.
+-  Remind publicly, and point out that some behavior/actions/language
+   have been judged inappropriate and why in the current context, or can
+   but hurtful to some people, requesting the community to self-adjust.
+-  A private reprimand from the committee to the individual(s) involved.
+   In this case, the group chair will deliver that reprimand to the
+   individual(s) over email, cc'ing the group.
+-  A public reprimand. In this case, the committee chair will deliver
+   that reprimand in the same venue that the violation occurred, within
+   the limits of practicality. E.g., the original mailing list for an
+   email violation, but for a chat room discussion where the
+   person/context may be gone, they can be reached by other means. The
+   group may choose to publish this message elsewhere for documentation
+   purposes.
+-  A request for a public or private apology, assuming the reporter
+   agrees to this idea: they may at their discretion refuse further
+   contact with the violator. The chair will deliver this request. The
+   committee may, if it chooses, attach "strings" to this request: for
+   example, the group may ask a violator to apologize in order to retain
+   one’s membership on a mailing list.
+-  A "mutually agreed upon hiatus" where the committee asks the
+   individual to temporarily refrain from community participation. If
+   the individual chooses not to take a temporary break voluntarily, the
+   committee may issue a "mandatory cooling off period".
+-  A permanent or temporary ban from some or all PySAL spaces (mailing
+   lists, gitter.im, etc.). The group will maintain records of all such
+   bans so that they may be reviewed in the future or otherwise
+   maintained.
+
+Once a resolution is agreed upon, but before it is enacted, the
+committee will contact the original reporter and any other affected
+parties and explain the proposed resolution. The committee will ask if
+this resolution is acceptable, and must note feedback for the record.
+
+Finally, the committee will make a report to the PySAL Steering Council
+(as well as the PySAL core team in the event of an ongoing resolution,
+such as a ban).
+
+The committee will never publicly discuss the issue; all public
+statements will be made by the chair of the Code of Conduct Committee.
+
+Conflicts of Interest
+---------------------
+
+In the event of any conflict of interest, a committee member must
+immediately notify the other members, and recuse themselves if
+necessary.

--- a/conduct/code_of_conduct.rst
+++ b/conduct/code_of_conduct.rst
@@ -1,0 +1,193 @@
+PySAL Code of Conduct
+=====================
+
+Introduction
+------------
+
+This code of conduct applies to all spaces managed by the PySAL project,
+including all public and private mailing lists, issue trackers, wikis,
+blogs, Twitter, and any other communication channel used by our
+community. The PySAL project does not organise in-person events, however
+events related to our community should have a code of conduct similar in
+spirit to this one.
+
+This code of conduct should be honored by everyone who participates in
+the PySAL community formally or informally, or claims any affiliation
+with the project, in any project-related activities and especially when
+representing the project, in any role.
+
+This code is not exhaustive or complete. It serves to distill our common
+understanding of a collaborative, shared environment and goals. Please
+try to follow this code in spirit as much as in letter, to create a
+friendly and productive environment that enriches the surrounding
+community.
+
+Specific Guidelines
+-------------------
+
+We strive to:
+
+#. Be open. We invite anyone to participate in our community. We prefer
+   to use public methods of communication for project-related messages,
+   unless discussing something sensitive. This applies to messages for
+   help or project-related support, too; not only is a public support
+   request much more likely to result in an answer to a question, it
+   also ensures that any inadvertent mistakes in answering are more
+   easily detected and corrected.
+
+#. Be empathetic, welcoming, friendly, and patient. We work together to
+   resolve conflict, and assume good intentions. We may all experience
+   some frustration from time to time, but we do not allow frustration
+   to turn into a personal attack. A community where people feel
+   uncomfortable or threatened is not a productive one.
+
+#. Be collaborative. Our work will be used by other people, and in turn
+   we will depend on the work of others. When we make something for the
+   benefit of the project, we are willing to explain to others how it
+   works, so that they can build on the work to make it even better. Any
+   decision we make will affect users and colleagues, and we take those
+   consequences seriously when making decisions.
+
+#. Be inquisitive. Nobody knows everything! Asking questions early
+   avoids many problems later, so we encourage questions, although we
+   may direct them to the appropriate forum. We will try hard to be
+   responsive and helpful.
+
+#. Be careful in the words that we choose. We are careful and respectful
+   in our communication and we take responsibility for our own speech.
+   Be kind to others. Do not insult or put down other participants. We
+   will not accept harassment or other exclusionary behaviour, such as:
+
+-  Violent threats or language directed against another person.
+-  Sexist, racist, or otherwise discriminatory jokes and language.
+-  Posting sexually explicit or violent material.
+-  Posting (or threatening to post) other people's personally
+   identifying information ("doxing").
+-  Sharing private content, such as emails sent privately or
+   non-publicly, or unlogged forums such as IRC channel history, without
+   the sender's consent.
+-  Personal insults, especially those using racist or sexist terms.
+-  Unwelcome sexual attention.
+-  Excessive profanity. Please avoid swearwords; people differ greatly
+   in their sensitivity to swearing.
+-  Repeated harassment of others. In general, if someone asks you to
+   stop, then stop.
+-  Advocating for, or encouraging, any of the above behaviour.
+
+
+Diversity Statement
+-------------------
+
+The PySAL project welcomes and encourages participation by everyone. We
+are committed to being a community that everyone enjoys being part of.
+Although we may not always be able to accommodate each individual's
+preferences, we try our best to treat everyone kindly.
+
+No matter how you identify yourself or how others perceive you: we
+welcome you. Though no list can hope to be comprehensive, we explicitly
+honour diversity in: age, culture, ethnicity, genotype, gender identity
+or expression, language, national origin, neurotype, phenotype,
+political beliefs, profession, race, religion, sexual orientation,
+socioeconomic status, subculture and technical ability, to the extent
+that these do not conflict with this code of conduct.
+
+Though we welcome people fluent in all languages, PySAL development is
+conducted in English.
+
+Standards for behaviour in the PySAL community are detailed in the Code
+of Conduct above. Participants in our community should uphold these
+standards in all their interactions and help others to do so as well
+(see next section).
+
+
+Reporting Guidelines
+--------------------
+
+We know that it is painfully common for internet communication to start
+at or devolve into obvious and flagrant abuse. We also recognize that
+sometimes people may have a bad day, or be unaware of some of the
+guidelines in this Code of Conduct. Please keep this in mind when
+deciding on how to respond to a breach of this Code.
+
+For clearly intentional breaches, report those to the Code of Conduct
+committee (see below). For possibly unintentional breaches, you may
+reply to the person and point out this code of conduct (either in public
+or in private, whatever is most appropriate). If you would prefer not to
+do that, please feel free to report to the Code of Conduct Committee
+directly, or ask the Committee for advice, in confidence.
+
+You can report issues to the PySAL Code of Conduct committee at
+pysal-conduct@googlegroups.com. Also, resolutions are announced via the
+`Code of Conduct gitter channel`_. Currently, the committee
+consists of:
+
+-  Stefanie Lumnitz
+
+   -  stefanie.lumnitz@gmail.com
+
+-  James Gaboardi
+
+   -  jgaboardi@gmail.com
+
+-  Eli Knapp
+
+   -  ek@knaaptime.com
+
+
+If your report involves any members of the committee, or if they feel
+they have a conflict of interest in handling it, then they will recuse
+themselves from considering your report. Alternatively, if for any
+reason you feel uncomfortable making a report to the committee, then you
+can also contact:
+
+-  To Be Determined
+   - <email@address.com>
+
+.. _Code of Conduct gitter channel: https://gitter.im/pysal/code_of_conduct
+
+
+Incident reporting resolution & Code of Conduct enforcement
+-----------------------------------------------------------
+
+*This section summarizes the most important points, more details can be
+found in the* `Code of Conduct Reporting Manual`_.
+
+We will investigate and respond to all complaints. The **PySAL Code of
+Conduct Committee** will protect the identity of the reporter, and treat
+the content of complaints as confidential (unless the reporter agrees
+otherwise).
+
+In case of severe and obvious breaches, e.g. personal threat or violent,
+sexist or racist language, we will immediately disconnect the originator
+from PySAL communication channels; please see the manual for details.
+
+In cases not involving clear severe and obvious breaches of this code of
+conduct, the process for acting on any received code of conduct
+violation report will be:
+
+#. acknowledge report is received
+#. reasonable discussion/feedback
+#. mediation (if feedback didn't help, and only if both reporter and
+   reportee agree to this)
+#. enforcement via transparent decision (see `Code of Conduct Reporting
+   Manual`_) by the Code of Conduct Committee
+
+The committee will respond to any report as soon as possible, and at
+most within 72 hours.
+
+.. _Code of Conduct Reporting Manual: coc_reporting.html
+
+
+Endnotes
+--------
+
+We are thankful to the groups behind the following documents, from which
+we drew content and inspiration:
+
+-  `NumPy Code of Conduct`_
+-  `SciPy Code of Conduct`_
+-  `Open Source Guides - Your Code of Conduct`_
+
+.. _NumPy Code of Conduct: https://github.com/numpy/numpy/blob/master/doc/source/dev/conduct/code_of_conduct.rst#id1
+.. _SciPy Code of Conduct: https://docs.scipy.org/doc/scipy/reference/dev/conduct/code_of_conduct.html
+.. _Open Source Guides - Your Code of Conduct: https://opensource.guide/code-of-conduct/


### PR DESCRIPTION
This PR includes:
- `governance/conduct/` subdirectory
- Within the subdirectory the following documents:
  - Code of Conduct
  - Code of Conduct reporting

This structure is based on that of the [`jupyter` project](https://github.com/jupyter/governance/tree/master/conduct).

@sjsrey @slumnitz @knaaptime