### PR TITLE
add wei to CoC -- update discord chat

### DIFF
--- a/conduct/code_of_conduct.rst
+++ b/conduct/code_of_conduct.rst
@@ -118,12 +118,12 @@ directly, or ask the Committee for advice, in confidence.
 
 You can report issues to the PySAL Code of Conduct committee at
 pysal-conduct@googlegroups.com. Also, resolutions are announced via the
-`Code of Conduct gitter channel`_. Currently, the committee
+`Code of Conduct discord channel`_. Currently, the committee
 consists of:
 
--  Stefanie Lumnitz
+-  Wei Kang
 
-   -  stefanie.lumnitz@gmail.com
+   -  WeiKang9009@gmail.com
 
 -  James Gaboardi
 
@@ -144,7 +144,7 @@ can also contact:
 
    - jkoschinsky@gmail.com
 
-.. _Code of Conduct gitter channel: https://gitter.im/pysal/code_of_conduct
+.. _Code of Conduct discord channel: https://discord.gg/MAzUtEtRNv
 
 
 Incident reporting resolution & Code of Conduct enforcement


### PR DESCRIPTION
This PR:
* supplements #12 
* add Wei to the Code of Conduct list
* updates the chat channel from gitter to Discord (https://github.com/pysal/pysal/issues/1296)
  * I created the channel with these settings: 
<img width="405" alt="Screenshot 2024-07-11 at 5 21 48 PM" src="https://github.com/user-attachments/assets/4a45d79a-2c9a-40e1-b8c2-6154a9a20a15">
